### PR TITLE
Fix grammar in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Open [http://localhost:3000](http://localhost:3000) with your browser to see the
 
 ## Notes
 
-- Went back and forth on how I can utilize searching with filtration with the least amount API calls as possible and decided with the following:
+ - Went back and forth on how I can utilize searching with filtration with the least amount of API calls as possible and decided with the following:
 - Initial page SSR (server side rendering) loaded with filters to show Next.js capabilities
 - CSR (client side rendering) for character search with a debounce to prevent excessive API calls
 - Didn't have enough time to implement filtering but skeleton is added.


### PR DESCRIPTION
## Summary
- fix grammar mistake in README (add missing word "of")

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855fbcd8e788323bd705055ca9a2986